### PR TITLE
[Chi-Hung] FIERpy updates

### DIFF
--- a/fierpy/fier.py
+++ b/fierpy/fier.py
@@ -1,6 +1,10 @@
 import numpy as np
 import xarray as xr
 import pandas as pd
+import random
+import scipy as sci
+import matplotlib
+import matplotlib.pyplot as plt
 
 import os
 import logging
@@ -10,12 +14,13 @@ from eofs.xarray import Eof
 from geoglows import streamflow
 from sklearn import metrics
 from sklearn.model_selection import train_test_split
+from typing import Tuple
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def reof(stack: xr.DataArray, variance_threshold: float = 0.727, n_modes: int = 4) -> xr.Dataset:
+def unrot_eof(stack: xr.DataArray, variance_threshold: float = 0.8, n_modes: int = -1) -> xr.Dataset:
     """Function to perform rotated empirical othogonal function (eof) on a spatial timeseries
 
     args:
@@ -62,6 +67,276 @@ def reof(stack: xr.DataArray, variance_threshold: float = 0.727, n_modes: int = 
     # get the indices where the eof is valid data
     non_masked_idx = np.where(np.logical_not(np.isnan(eof_components[:,0])))[0]
 
+    # # waiting for release of sklean version >= 0.24
+    # # until then have a placeholder function to do the rotation
+    # fa = FactorAnalysis(n_components=n_modes, rotation="varimax")
+    # rotated[non_masked_idx,:] = fa.fit_transform(eof_components[non_masked_idx,:])
+
+    # get eof with valid data
+    eof_components = np.asarray(eof_components)
+
+    
+    # project the original time series data on the rotated eofs
+    projected_pcs = np.dot(centered[:,non_masked_idx], eof_components[non_masked_idx,:])
+
+    # reshape the rotated eofs to a 3d array of [y,x,c]
+    spatial = eof_components.reshape(spatial_shape+(n_modes,))
+    
+    
+    # structure the spatial and temporal eof components in a Dataset
+    eof_ds = xr.Dataset(
+        {
+            "spatial_modes": (["lat","lon","mode"],spatial),
+            "temporal_modes":(["time","mode"],projected_pcs),
+            "center": (["lat","lon"],center.values.reshape(spatial_shape))
+        },
+        coords = {
+            "lon":(["lon"],stack.lon),
+            "lat":(["lat"],stack.lat),
+            "time":stack.time,
+            "mode": np.arange(n_modes)+1
+        }
+    )
+
+    return eof_ds
+    
+    
+def sig_eof_mode(stack: xr.DataArray, option: int=0, monte_carlo_iter: int=1000) -> int:
+    """
+       Significant test upon the EOF analysis results.
+       
+       Option:
+       1. Monte Carlo Test
+       2. 
+       3. 
+       
+    """          
+    
+    fontdict={
+       'weight':'bold',
+       'size':14    
+    }
+    matplotlib.rc('font',**fontdict)
+    
+    # extract out some dimension shape information
+    shape3d = stack.shape
+    spatial_shape = shape3d[1:]
+    shape2d = (shape3d[0],np.prod(spatial_shape))
+
+    # flatten the data from [t,y,x] to [t,...]
+    da_flat = xr.DataArray(
+        stack.values.reshape(shape2d),
+        coords = [stack.time,np.arange(shape2d[1])],
+        dims=['time','space']
+    )
+    #logger.debug(da_flat)
+        
+    ## find the temporal mean for each pixel
+    center = da_flat.mean(dim='time')
+    
+    centered = da_flat - center
+    centered = centered.dropna(dim='space')
+    
+    pix_num = centered.sizes['space']
+    obs_num = centered.sizes['time']
+    
+    # Get eigenvalue from real data   
+    solver_real = Eof(centered,center=False)
+    real_lamb = np.array(solver_real.eigenvalues(neigs = obs_num))
+       
+    sig_mode = 0
+    if option==1:
+       print('Perform Monte Carlo significant test')
+       
+       rng = np.random.default_rng()      
+       
+       #Xp: space x time
+       #Xp[,j][sample(nrow(Xp))]
+       #Means for j-th column (with nrow of data), shuffule with size of nrow.
+       
+       mc_lamb = np.full((obs_num,monte_carlo_iter),np.nan)
+             
+       random.seed(1)
+       for i in range(monte_carlo_iter):
+         #print('Iteration: ',str(i+1))
+         
+         # ----- Randomize observation (space-wise randomization)
+         # ----- with for loop -----
+         #obs_temp = np.full((obs_num,pix_num), np.nan)         
+         #for j in range(obs_num): # time-wise
+         #  print('Randomization',str(j))
+         #  obs_temp[j,:] = random.sample(list(centered[j,:].values), pix_num)         
+         
+         # ----- Some vectorization -----
+         #idx = np.random.rand(obs_num, pix_num).argsort(axis=1)
+         #obs_temp = np.take_along_axis(centered.values,idx,axis=1)
+         
+         # ----- Some vectorization 1 -----
+         obs_temp = rng.permuted(centered.values, axis=1)
+         
+         obs_temp = xr.DataArray(
+              obs_temp,
+              coords=[centered.time,np.arange(pix_num)],
+              dims=['time','space']
+         )        
+         
+         #obs_temp = obs_temp.chunk({'time':10000000000,'space':10000000000})         
+         solver_mc = Eof(obs_temp,center=False)
+         #print(solver_mc.eigenvalues(neigs = obs_num))
+         mc_lamb[:,i] = solver_mc.eigenvalues(neigs = obs_num)
+          
+       mc_lamb = np.transpose(mc_lamb)
+       mean_mc_lamb = np.mean(mc_lamb,axis=0)
+       std_mc_lamb = np.std(mc_lamb,axis=0)
+       
+       gt = np.greater(real_lamb, mean_mc_lamb).astype(int)
+       gt_rev = gt[::-1]
+       sig_mode = len(gt_rev) - np.argmax(gt_rev) - 1
+       
+       plt.title('Scree Plot',fontdict=fontdict)
+       plt.plot(np.arange(obs_num)+1, real_lamb, marker='+')
+       plt.errorbar(np.arange(obs_num)+1, mean_mc_lamb, std_mc_lamb)
+       plt.legend(['Real Data','MonteCarlo Sim. Data'])
+       plt.xlabel('Mode',fontdict=fontdict)
+       plt.ylabel('Eigenvalue',fontdict=fontdict)
+       plt.show()       
+              
+    return sig_mode
+                                                           
+    
+def modes_rtpc2hydro(reof_stack: xr.Dataset, hydro_stack: xr.DataArray, spearman_r_threshold: float=0.6) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:   
+    """
+       Calculate Spearman's R (monotonic correlation) between RTPC and hydrological data. This help determine which 
+       modes are water-related. The threshold of Spearman's R is defined as >=0.6 by default based on the interpretation
+       of 
+
+    """    
+    # get number of mode     
+    mode_num = reof_stack.sizes['mode']    
+    # get number of hydrological data sites
+    site_num = hydro_stack.sizes['site']    
+    
+    mono_r = np.zeros((site_num, mode_num))
+    mono_p = np.zeros((site_num, mode_num))
+    linr_r = np.zeros((site_num, mode_num))
+    linr_p = np.zeros((site_num, mode_num))
+    
+    
+    for ct_mode in range(mode_num):
+      # get mode of tpc
+      tpc = reof_stack.temporal_modes.sel(mode=int(ct_mode+1))    
+      
+      for ct_site in range(site_num):
+        # get hydrological data coincident with satellite images (TPC) 
+        if hydro_stack[ct_site].sizes['time'] != reof_stack.sizes['time']:        
+          hydro_site = match_dates(hydro_stack[ct_site], tpc)
+        else:
+          hydro_site = hydro_stack[ct_site]
+    
+        hydro_zscore = sci.stats.zscore(hydro_site)                
+        indx_good_hydro = (np.abs(hydro_zscore) <= 3)
+        
+        #good_hydro = hydro_site
+        #good_tpc = tpc
+        
+        good_hydro = hydro_site[indx_good_hydro]
+        good_tpc = tpc[indx_good_hydro]    
+
+        #plt.scatter(good_tpc, good_hydro)
+        #plt.show()        
+    
+        # calculate monotonic correlation between hydrological data and tpc
+        # as a reference to judge their connection
+        mono_r[ct_site, ct_mode] = sci.stats.spearmanr(good_tpc, good_hydro)[0]
+        mono_p[ct_site, ct_mode] = sci.stats.spearmanr(good_tpc, good_hydro)[1]
+        linr_r[ct_site, ct_mode] = sci.stats.pearsonr(good_tpc, good_hydro)[0]
+        linr_p[ct_site, ct_mode] = sci.stats.pearsonr(good_tpc, good_hydro)[1]
+        
+    indx_site_mode = ((np.abs(mono_r) >= spearman_r_threshold).astype(int)).nonzero()
+    
+    
+    return mono_r, mono_p, linr_r, linr_p, indx_site_mode
+        
+        
+def wrap_streamflow(lats: list, lons: list) -> Tuple[xr.DataArray, list]:
+    """Function to get and wrap up histroical streamflow data from the GeoGLOWS server
+    at different geographic coordinates
+
+    args:
+        lats (list): latitude values where to get streamflow data
+        lons (list): longitude values where to get streamflow data
+
+    returns:
+        xr.DataArray: DataArray object of streamflow with datetime coordinates
+    """
+    site_num = len(lats)
+    reaches = []
+    for ct_site in range(site_num):
+      if ct_site==0:
+        q, reach_id = get_streamflow(lats[ct_site], lons[ct_site])
+        q["time"] = q["time"].dt.strftime("%Y-%m-%d")
+        q.expand_dims(dim='site')
+      else:
+        q1, reach_id = get_streamflow(lats[ct_site], lons[ct_site])
+        q1["time"] = q1["time"].dt.strftime("%Y-%m-%d")        
+        q = xr.concat( (q, q1),dim='site' ) 
+      reaches.append(reach_id)
+      
+    # return the series as a xr.DataArray
+    return q, reaches      
+
+
+def reof(stack: xr.DataArray, variance_threshold: float = 0.727, n_modes: int = 4) -> xr.Dataset:
+    """Function to perform rotated empirical othogonal function (eof) on a spatial timeseries
+
+    args:
+        stack (xr.DataArray): DataArray of spatial temporal values with coord order of (t,y,x)
+        variance_threshold(float, optional): optional fall back value to select number of eof
+            modes to use. Only used if n_modes is less than 1. default = 0.727
+        n_modes (int, optional): number of eof modes to use. default = 4
+
+    returns:
+        xr.Dataset: rotated eof dataset with spatial modes, temporal modes, and mean values
+            as variables
+
+    """
+    # extract out some dimension shape information
+    shape3d = stack.shape
+    spatial_shape = shape3d[1:]
+    shape2d = (shape3d[0],np.prod(spatial_shape))
+
+    # flatten the data from [t,y,x] to [t,...]
+    da_flat = xr.DataArray(
+        stack.values.reshape(shape2d),
+        coords = [stack.time,np.arange(shape2d[1])],
+        dims=['time','space']
+    )
+    #logger.debug(da_flat)
+        
+    ## find the temporal mean for each pixel
+    center = da_flat.mean(dim='time')
+    
+    centered = da_flat - center
+               
+    # get an eof solver object
+    # explicitly set center to false since data is already
+    #solver = Eof(centered,center=False)
+    solver = Eof(centered,center=False)
+
+    # check if the n_modes keyword is set to a realistic value
+    # if not get n_modes based on variance explained
+    if n_modes < 0:
+        n_modes = int((solver.varianceFraction().cumsum() < variance_threshold).sum())
+
+    # calculate to spatial eof values
+    eof_components = solver.eofs(neofs=n_modes).transpose()
+    
+    # get total variance fractions of eof (up to the max. retained mode)
+    total_eof_var_frac = solver.varianceFraction(neigs=n_modes).cumsum()
+    
+    # get the indices where the eof is valid data
+    non_masked_idx = np.where(np.logical_not(np.isnan(eof_components[:,0])))[0]
+
     # create a "blank" array to set roated values to
     rotated = eof_components.values.copy()
 
@@ -76,9 +351,25 @@ def reof(stack: xr.DataArray, variance_threshold: float = 0.727, n_modes: int = 
 
     # project the original time series data on the rotated eofs
     projected_pcs = np.dot(centered[:,non_masked_idx], rotated[non_masked_idx,:])
-
+    
+    print(projected_pcs.shape)
+    
+    # get variance of each rotated mode
+    rot_var = np.var(projected_pcs, axis=0)
+    # get variance of all rotated modes
+    total_rot_var = rot_var.cumsum()
+    # get variance fraction of each rotated mode
+    rot_var_frac = ((rot_var/total_rot_var)*total_eof_var_frac)*100
+    
     # reshape the rotated eofs to a 3d array of [y,x,c]
     spatial_rotated = rotated.reshape(spatial_shape+(n_modes,))
+
+    # sort modes based on variance fraction of REOF
+    indx_rot_var_frac_sort = np.expand_dims(((np.argsort(-1*rot_var_frac)).data), axis=0)        
+    projected_pcs = np.take_along_axis(projected_pcs,indx_rot_var_frac_sort,axis=1)
+    
+    indx_rot_var_frac_sort = np.expand_dims(indx_rot_var_frac_sort, axis=0)
+    spatial_rotated = np.take_along_axis(spatial_rotated,indx_rot_var_frac_sort,axis=2)
 
     # structure the spatial and temporal reof components in a Dataset
     reof_ds = xr.Dataset(
@@ -121,7 +412,9 @@ def _ortho_rotation(components: np.array, method: str = 'varimax', tol: float = 
     return np.dot(components, rotation_matrix)
 
 
-def get_streamflow(lat: float, lon: float) -> xr.DataArray:
+
+
+def get_streamflow(lat: float, lon: float) -> Tuple[xr.DataArray, int]:
     """Function to get histroical streamflow data from the GeoGLOWS server
     based on geographic coordinates
 
@@ -145,7 +438,7 @@ def get_streamflow(lat: float, lon: float) -> xr.DataArray:
     q.index = q.index.tz_localize(None)
 
     # return the series as a xr.DataArray
-    return q.discharge.to_xarray()
+    return q.discharge.to_xarray(), reach['reach_id']
 
 
 def match_dates(original: xr.DataArray, matching: xr.DataArray) -> xr.DataArray:


### PR DESCRIPTION
Hi Kel,

This is Chi-Hung. I have added some functions to the current FIERpy:
1. unrot_eof: To perform conventional non-rotated EOF analysis.
2. sig_eof_test: To perform significant test which help decide the number of EOF modes retained for rotation (for REOF). Currently I have implemented the Monte Carlo test.
3. find_hydro_mode: Identify water-related EOF/REOF modes based on Spearman's correlation between RTPC/TPC with hydrological data.
4. wrap_streamflow: Allow users to enter a list for latitude and longitude at multiple river reaches. This is for users that are interested in using multiple reaches of data as input.

I also slightly modified some existing functions:
1. reof: I have added few lines which calculate and sort the explained variance fraction after rotation.
2. get_streamflow: Now also return GEOGloWS reach ID.